### PR TITLE
Fetch order history from server after executing trades

### DIFF
--- a/static/js/ dashboard.js
+++ b/static/js/ dashboard.js
@@ -2,6 +2,18 @@ document.addEventListener('DOMContentLoaded', () => {
   // Histórico local (simulação visual)
   let historico = [];
 
+  async function atualizarHistorico() {
+    try {
+      const resp = await fetch("/historico");
+      if (resp.ok) {
+        historico = await resp.json();
+        renderHistorico();
+      }
+    } catch (e) {
+      console.error("Erro ao atualizar histórico", e);
+    }
+  }
+
   function renderHistorico() {
     const ordensList = document.getElementById('ordens-list');
     if (!ordensList) return;
@@ -13,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  window.confirmarOrdem = function(tipo) {
+  window.confirmarOrdem = async function(tipo) {
     let msg = "Tem certeza que deseja executar essa ordem?";
     if (tipo === "buy") msg = "Confirmar compra?";
     if (tipo === "sell") msg = "Confirmar venda?";
@@ -21,20 +33,37 @@ document.addEventListener('DOMContentLoaded', () => {
     if (tipo === "auto") msg = "Ativar modo automático?";
     if (confirm(msg)) {
       let valor = document.getElementById("qtd_input")?.value || "0.001";
-      historico.unshift({
-        tipo: tipo === "buy" ? "Compra" :
-              tipo === "sell" ? "Venda" :
-              tipo === "suggest" ? "Sugestão IA" : "Automático",
-        ativo: "BTCUSDT",
-        valor: valor,
-        preco: "ao vivo",
-        hora: new Date().toLocaleTimeString().slice(0,5)
-      });
-      renderHistorico();
-      alert("Ordem executada!");
-      // Para ordens reais, faça requisição Ajax para /executar_ordem
+      if (tipo === "buy" || tipo === "sell") {
+        const form = new URLSearchParams();
+        form.append("tipo", tipo === "buy" ? "compra" : "venda");
+        form.append("quantidade", valor);
+        try {
+          const resp = await fetch("/executar_ordem", {
+            method: "POST",
+            headers: {"Content-Type": "application/x-www-form-urlencoded"},
+            body: form.toString()
+          });
+          if (resp.ok) {
+            alert("Ordem executada!");
+            await atualizarHistorico();
+          } else {
+            alert("Erro ao executar ordem");
+          }
+        } catch (e) {
+          console.error("Erro ao executar ordem", e);
+        }
+      } else {
+        historico.unshift({
+          tipo: tipo === "suggest" ? "Sugestão IA" : "Automático",
+          ativo: "BTCUSDT",
+          valor: valor,
+          preco: "ao vivo",
+          hora: new Date().toLocaleTimeString().slice(0,5)
+        });
+        renderHistorico();
+      }
     }
   };
 
-  renderHistorico();
+  atualizarHistorico();
 });


### PR DESCRIPTION
## Summary
- add `atualizarHistorico` to load latest orders from the server
- refresh order list after executing a trade instead of locally pushing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688beeaa24488329b7bb9c39d6119625