### PR TITLE
Handle missing OpenAI API key and adapt Flask startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,6 @@ class Usuario(db.Model):
     senha_hash = db.Column(db.String(128), nullable=False)
 
 # Criar banco e garantir admin
-@app.before_first_request
 def criar_admin():
     db.create_all()
     admin = Usuario.query.filter_by(usuario="admin").first()
@@ -30,6 +29,9 @@ def criar_admin():
         novo_admin = Usuario(usuario="admin", senha_hash=senha_hash)
         db.session.add(novo_admin)
         db.session.commit()
+
+with app.app_context():
+    criar_admin()
 
 @app.route("/")
 def index():

--- a/clarinha_gpt_guardian.py
+++ b/clarinha_gpt_guardian.py
@@ -1,7 +1,8 @@
 from openai import OpenAI
 import os
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=api_key) if api_key else None
 
 def interpretar_pergunta(pergunta_usuario):
     prompt = (
@@ -10,6 +11,8 @@ def interpretar_pergunta(pergunta_usuario):
         "existenciais e operacionais sobre o mundo financeiro.\n"
         f"Pergunta: {pergunta_usuario}"
     )
+    if client is None:
+        return "OPENAI_API_KEY não configurada"
     try:
         resp = client.chat.completions.create(
             model="gpt-4o-mini",

--- a/clarinha_ia.py
+++ b/clarinha_ia.py
@@ -3,8 +3,9 @@ import requests
 import json
 import os
 
-# Cliente OpenAI com chave do ambiente
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+# Cliente OpenAI com chave do ambiente (opcional)
+api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=api_key) if api_key else None
 
 def obter_dados_mercado(simbolo="BTCUSDT"):
     try:
@@ -39,6 +40,15 @@ def solicitar_analise_json(simbolo="BTCUSDT"):
             "stop": "-",
             "confianca": 0,
             "sugestao": dados["erro"]
+        }
+
+    if client is None:
+        return {
+            "entrada": "-",
+            "alvo": "-",
+            "stop": "-",
+            "confianca": 0,
+            "sugestao": "OPENAI_API_KEY não configurada"
         }
 
     prompt = f"""

--- a/clarinha_visionary.py
+++ b/clarinha_visionary.py
@@ -1,8 +1,9 @@
 from openai import OpenAI
 import os
 
-# Cliente OpenAI
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+# Cliente OpenAI (opcional)
+api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=api_key) if api_key else None
 
 def gerar_imagem_oracular(descricao_imagem):
     prompt = f"""
@@ -15,6 +16,8 @@ Crie uma imagem com base na seguinte descrição intuitiva:
 A imagem deve ser inspiradora, etérea e carregar profundidade espiritual.
 Estilo artístico com cores suaves, simbolismo e leveza visual são preferíveis.
 """
+    if client is None:
+        return "OPENAI_API_KEY não configurada"
     try:
         resp = client.images.generate(
             model="gpt-image-1",


### PR DESCRIPTION
## Summary
- Avoid initialization errors when `OPENAI_API_KEY` is not set
- Provide clear fallback messages in Clarinha modules
- Replace removed Flask `before_first_request` hook with explicit startup admin creation

## Testing
- `pytest`
- `python - <<'PY'
from clarinha_core import clarinha_responder
print(clarinha_responder('Qual a tendência do BTC?', gerar_imagem=False))
PY`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688f0bab263883299e7a3dc871e4dada