### PR TITLE
Enable real-money trading and enforce API credentials

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,12 @@
-from flask import Flask, render_template, request, redirect, url_for, session, flash
+from flask import Flask, render_template, request, redirect, url_for, session, flash, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import generate_password_hash, check_password_hash
 from dotenv import load_dotenv
 import os
+import json
+from datetime import datetime
+from clarinha_ia import solicitar_analise_json
+from binance_trade import executar_ordem as executar_ordem_binance
 
 load_dotenv()
 
@@ -21,7 +25,6 @@ class Usuario(db.Model):
     senha_hash = db.Column(db.String(128), nullable=False)
 
 # Criar banco e garantir admin
-@app.before_first_request
 def criar_admin():
     db.create_all()
     admin = Usuario.query.filter_by(usuario="admin").first()
@@ -30,6 +33,9 @@ def criar_admin():
         novo_admin = Usuario(usuario="admin", senha_hash=senha_hash)
         db.session.add(novo_admin)
         db.session.commit()
+
+with app.app_context():
+    criar_admin()
 
 @app.route("/")
 def index():
@@ -76,6 +82,71 @@ def painel_operacao():
     if not session.get("logado"):
         return redirect(url_for("login"))
     return render_template("painel_operacao.html")
+
+
+@app.route("/historico")
+def historico():
+    if not session.get("logado"):
+        return jsonify([]), 401
+    if os.path.exists("orders.json"):
+        with open("orders.json", "r") as f:
+            data = json.load(f)
+    else:
+        data = []
+    return jsonify(data)
+
+
+@app.route("/executar_ordem", methods=["POST"])
+def executar_ordem():
+    if not session.get("logado"):
+        return "Não autenticado", 401
+    tipo = request.form.get("tipo")
+    quantidade = request.form.get("quantidade", "0.001")
+    side = "BUY" if tipo == "compra" else "SELL"
+    try:
+        resultado = executar_ordem_binance("BTCUSDT", side, quantidade)
+        ordem = {
+            "tipo": tipo,
+            "ativo": "BTCUSDT",
+            "valor": quantidade,
+            "preco": resultado.get("fills", [{}])[0].get("price", "0"),
+            "hora": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        }
+        if os.path.exists("orders.json"):
+            with open("orders.json", "r") as f:
+                historico = json.load(f)
+        else:
+            historico = []
+        historico.append(ordem)
+        with open("orders.json", "w") as f:
+            json.dump(historico, f, indent=2)
+        return jsonify({"status": "ok"})
+    except Exception as e:
+        return str(e), 500
+
+
+@app.route("/sugestao_ia")
+def sugestao_ia():
+    if not session.get("logado"):
+        return jsonify({"status": "erro", "mensagem": "não autenticado"}), 401
+    quantidade = request.args.get("quantidade", "0.001")
+    analise = solicitar_analise_json()
+    texto = analise.get("sugestao", "").lower()
+    if "compra" in texto:
+        tipo = "compra"
+    elif "venda" in texto:
+        tipo = "venda"
+    else:
+        tipo = None
+    status = "ok" if tipo else "erro"
+    return jsonify({"status": status, "tipo": tipo, "quantidade": quantidade, "analise": analise})
+
+
+@app.route("/modo_automatico", methods=["POST"])
+def modo_automatico():
+    if not session.get("logado"):
+        return jsonify({"erro": "não autenticado"}), 401
+    return jsonify({"status": "ok"})
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/binance_trade.py
+++ b/binance_trade.py
@@ -1,0 +1,34 @@
+import os
+import time
+import hmac
+import hashlib
+import requests
+from urllib.parse import urlencode
+
+API_KEY = os.getenv("BINANCE_API_KEY")
+API_SECRET = os.getenv("BINANCE_API_SECRET")
+BASE_URL = "https://api.binance.com"
+
+
+def _signed_request(method, path, params):
+    if not API_KEY or not API_SECRET:
+        raise EnvironmentError("Chaves da Binance não configuradas")
+    params['timestamp'] = int(time.time() * 1000)
+    query = urlencode(params)
+    signature = hmac.new(API_SECRET.encode(), query.encode(), hashlib.sha256).hexdigest()
+    headers = {'X-MBX-APIKEY': API_KEY}
+    url = f"{BASE_URL}{path}?{query}&signature={signature}"
+    resp = requests.request(method, url, headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def executar_ordem(symbol, side, quantity):
+    params = {
+        'symbol': symbol,
+        'side': side,
+        'type': 'MARKET',
+        'quantity': quantity,
+    }
+    return _signed_request('POST', '/api/v3/order', params)
+

--- a/clarinha_gpt_guardian.py
+++ b/clarinha_gpt_guardian.py
@@ -1,7 +1,10 @@
 from openai import OpenAI
 import os
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise EnvironmentError("OPENAI_API_KEY não configurada")
+client = OpenAI(api_key=api_key)
 
 def interpretar_pergunta(pergunta_usuario):
     prompt = (
@@ -19,3 +22,4 @@ def interpretar_pergunta(pergunta_usuario):
         return resp.choices[0].message.content
     except Exception as e:
         return f"Clarinha ficou em silêncio cósmico: {e}"
+

--- a/clarinha_ia.py
+++ b/clarinha_ia.py
@@ -3,8 +3,10 @@ import requests
 import json
 import os
 
-# Cliente OpenAI com chave do ambiente
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise EnvironmentError("OPENAI_API_KEY não configurada")
+client = OpenAI(api_key=api_key)
 
 def obter_dados_mercado(simbolo="BTCUSDT"):
     try:

--- a/clarinha_visionary.py
+++ b/clarinha_visionary.py
@@ -1,8 +1,10 @@
 from openai import OpenAI
 import os
 
-# Cliente OpenAI
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise EnvironmentError("OPENAI_API_KEY não configurada")
+client = OpenAI(api_key=api_key)
 
 def gerar_imagem_oracular(descricao_imagem):
     prompt = f"""


### PR DESCRIPTION
## Summary
- Require configured OpenAI API key in Clarinha modules to ensure real interactions
- Add Binance trading client and Flask routes for live order execution and history using environment credentials

## Testing
- `OPENAI_API_KEY=dummy pytest`
- `OPENAI_API_KEY=dummy python - <<'PY'
from clarinha_core import clarinha_responder
print(clarinha_responder('Qual a tendência do BTC?', gerar_imagem=False))
PY`
- `python -m py_compile app.py clarinha_gpt_guardian.py clarinha_ia.py clarinha_visionary.py binance_trade.py`


------
https://chatgpt.com/codex/tasks/task_e_688f0bab263883299e7a3dc871e4dada