### PR TITLE
Add Binance and OpenAI key management with auto trading scheduler

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,13 @@
 from flask import Flask, render_template, request, redirect, url_for, session, flash, jsonify
-from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import generate_password_hash, check_password_hash
 from dotenv import load_dotenv
 import os
 import json
-from datetime import datetime
 from clarinha_ia import solicitar_analise_json
-from binance_trade import executar_ordem as executar_ordem_binance
+from models import db, Usuario, BinanceKey
+from crypto_utils import criptografar
+from binance_client import get_client
+from tasks import start_auto_mode, stop_auto_mode
 
 load_dotenv()
 
@@ -16,17 +17,7 @@ app.secret_key = os.getenv("FLASK_SECRET_KEY", "super_secret_key")
 # Configuração do banco SQLite
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///usuarios.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-db = SQLAlchemy(app)
-
-# Controle de modo automático
-auto_thread = None
-auto_running = False
-
-# Modelo de Usuário
-class Usuario(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    usuario = db.Column(db.String(80), unique=True, nullable=False)
-    senha_hash = db.Column(db.String(128), nullable=False)
+db.init_app(app)
 
 # Criar banco e garantir admin
 def criar_admin():
@@ -88,6 +79,35 @@ def painel_operacao():
     return render_template("painel_operacao.html")
 
 
+@app.route("/config_api", methods=["GET", "POST"])
+def config_api():
+    if not session.get("logado"):
+        return redirect(url_for("login"))
+    usuario = Usuario.query.filter_by(usuario=session["usuario"]).first()
+    cred = BinanceKey.query.filter_by(user_id=usuario.id).first()
+    if request.method == "POST":
+        api_key = request.form["api_key"]
+        api_secret = request.form["api_secret"]
+        testnet = bool(request.form.get("testnet"))
+        openai_key = request.form.get("openai_key")
+        api_key_enc = criptografar(api_key, usuario.usuario)
+        api_secret_enc = criptografar(api_secret, usuario.usuario)
+        openai_key_enc = criptografar(openai_key, usuario.usuario) if openai_key else None
+        if cred:
+            cred.api_key = api_key_enc
+            cred.api_secret = api_secret_enc
+            cred.testnet = testnet
+            if openai_key:
+                cred.openai_key = openai_key_enc
+        else:
+            cred = BinanceKey(user_id=usuario.id, api_key=api_key_enc, api_secret=api_secret_enc, testnet=testnet, openai_key=openai_key_enc)
+            db.session.add(cred)
+        db.session.commit()
+        flash("Chaves atualizadas!", "success")
+        return redirect(url_for("painel_operacao"))
+    return render_template("config_api.html", binance_key=cred)
+
+
 @app.route("/historico")
 def historico():
     if not session.get("logado"):
@@ -107,9 +127,9 @@ def executar_ordem():
     quantidade = request.form.get("quantidade", "0.001")
     side = "BUY" if tipo == "compra" else "SELL"
     try:
-        resultado = executar_ordem_binance("BTCUSDT", side, quantidade)
-
-        return jsonify({"status": "ok"})
+        client = get_client(session["usuario"])
+        ordem = client.create_order(symbol="BTCUSDT", side=side, type="MARKET", quantity=quantidade)
+        return jsonify({"status": "ok", "order": ordem})
     except Exception as e:
         return str(e), 500
 
@@ -119,7 +139,7 @@ def sugestao_ia():
     if not session.get("logado"):
         return jsonify({"status": "erro", "mensagem": "não autenticado"}), 401
     quantidade = request.args.get("quantidade", "0.001")
-    analise = solicitar_analise_json()
+    analise = solicitar_analise_json(session["usuario"])
     texto = analise.get("sugestao", "").lower()
     if "compra" in texto:
         tipo = "compra"
@@ -135,8 +155,13 @@ def sugestao_ia():
 def modo_automatico():
     if not session.get("logado"):
         return jsonify({"erro": "não autenticado"}), 401
-
-    return jsonify({"status": "ok"})
+    acao = request.form.get("acao")
+    usuario = session["usuario"]
+    if acao == "start":
+        start_auto_mode(usuario)
+    elif acao == "stop":
+        stop_auto_mode(usuario)
+    return jsonify({"status": "ok", "acao": acao})
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/binance_client.py
+++ b/binance_client.py
@@ -1,0 +1,21 @@
+from binance.client import Client
+from models import Usuario, BinanceKey
+from crypto_utils import descriptografar
+
+
+def get_client(usuario_nome: str) -> Client:
+    """Retorna um cliente da Binance para o usuário dado."""
+    usuario = Usuario.query.filter_by(usuario=usuario_nome).first()
+    if not usuario:
+        raise ValueError("Usuário não encontrado")
+
+    cred = BinanceKey.query.filter_by(user_id=usuario.id).first()
+    if not cred:
+        raise ValueError("Chaves da Binance não configuradas")
+
+    api_key = descriptografar(cred.api_key, usuario.usuario)
+    api_secret = descriptografar(cred.api_secret, usuario.usuario)
+    client = Client(api_key, api_secret, testnet=cred.testnet)
+    if cred.testnet:
+        client.API_URL = 'https://testnet.binance.vision/api'
+    return client

--- a/clarinha_core.py
+++ b/clarinha_core.py
@@ -4,7 +4,7 @@ from clarinha_visionary import gerar_imagem_oracular
 
 def clarinha_responder(pergunta, simbolo="BTCUSDT", gerar_imagem=False):
     resposta_gpt = interpretar_pergunta(pergunta)
-    analise_json = solicitar_analise_json(simbolo)
+    analise_json = solicitar_analise_json(simbolo=simbolo)
     imagem_url = gerar_imagem_oracular(pergunta) if gerar_imagem else "Imagem não solicitada."
 
     return {

--- a/crypto_utils.py
+++ b/crypto_utils.py
@@ -35,9 +35,7 @@ def criptografar(texto, usuario):
     return f.encrypt(texto.encode()).decode()
 
 def descriptografar(token, usuario):
-    """
-    Descriptografa o token com a chave do usuário
-    """
+    """Descriptografa o token com a chave do usuário."""
     chave = carregar_chave(usuario)
     f = Fernet(chave)
     return f.decrypt(token.encode()).decode()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,24 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# Instância global do banco de dados
+
+db = SQLAlchemy()
+
+
+class Usuario(db.Model):
+    __tablename__ = 'usuario'
+    id = db.Column(db.Integer, primary_key=True)
+    usuario = db.Column(db.String(80), unique=True, nullable=False)
+    senha_hash = db.Column(db.String(128), nullable=False)
+
+
+class BinanceKey(db.Model):
+    __tablename__ = 'binance_key'
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
+    api_key = db.Column(db.String(255), nullable=False)
+    api_secret = db.Column(db.String(255), nullable=False)
+    testnet = db.Column(db.Boolean, default=True)
+    openai_key = db.Column(db.String(255))
+
+    usuario = db.relationship('Usuario', backref=db.backref('binance_key', uselist=False))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pycryptodome==3.20.0
 Flask-JWT-Extended==4.6.0
 psycopg2-binary==2.9.9
 requests==2.31.0
+APScheduler==3.10.4

--- a/strategy.py
+++ b/strategy.py
@@ -1,0 +1,20 @@
+from clarinha_ia import solicitar_analise_json
+
+
+def decide_and_execute(usuario_nome: str, client) -> dict:
+    """Consulta a IA e executa uma ordem simples com salvaguardas."""
+    analise = solicitar_analise_json(usuario_nome)
+    texto = analise.get("sugestao", "").lower()
+    if "compra" in texto:
+        side = "BUY"
+    elif "venda" in texto:
+        side = "SELL"
+    else:
+        return {"executado": False, "motivo": "Sem sinal claro", "analise": analise}
+
+    quantidade = "0.001"
+    try:
+        order = client.create_order(symbol="BTCUSDT", side=side, type="MARKET", quantity=quantidade)
+        return {"executado": True, "ordem": order, "analise": analise}
+    except Exception as e:
+        return {"executado": False, "erro": str(e), "analise": analise}

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,35 @@
+try:
+    from apscheduler.schedulers.background import BackgroundScheduler
+except ModuleNotFoundError:  # pragma: no cover - fallback when APScheduler missing
+    BackgroundScheduler = None
+
+from binance_client import get_client
+from strategy import decide_and_execute
+
+
+if BackgroundScheduler:
+    scheduler = BackgroundScheduler()
+    scheduler.start()
+else:  # simple placeholder to avoid runtime errors when APScheduler isn't installed
+    scheduler = None
+
+
+def auto_trade(usuario_nome: str):
+    client = get_client(usuario_nome)
+    decide_and_execute(usuario_nome, client)
+
+
+def start_auto_mode(usuario_nome: str, interval: int = 60):
+    if scheduler is None:
+        raise RuntimeError("APScheduler não instalado")
+    job_id = f"auto-{usuario_nome}"
+    scheduler.add_job(auto_trade, "interval", [usuario_nome], seconds=interval, id=job_id, replace_existing=True)
+
+
+def stop_auto_mode(usuario_nome: str):
+    if scheduler is None:
+        raise RuntimeError("APScheduler não instalado")
+    job_id = f"auto-{usuario_nome}"
+    job = scheduler.get_job(job_id)
+    if job:
+        scheduler.remove_job(job_id)

--- a/templates/config_api.html
+++ b/templates/config_api.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Configurar Binance{% endblock %}
+{% block content %}
+<h2>Configurar API da Binance</h2>
+<form method="post">
+  <label>API Key:<br><input type="text" name="api_key" required></label><br>
+  <label>API Secret:<br><input type="text" name="api_secret" required></label><br>
+  <label>OpenAI Key:<br><input type="text" name="openai_key"></label><br>
+  <label><input type="checkbox" name="testnet" {% if binance_key and binance_key.testnet %}checked{% endif %}> Usar Testnet</label><br>
+  <button type="submit">Salvar</button>
+</form>
+{% endblock %}

--- a/templates/painel_operacao.html
+++ b/templates/painel_operacao.html
@@ -15,8 +15,13 @@
   <button onclick="executarAcao('stop')">STOP</button>
   <button onclick="executarAcao('alvo')">ALVO</button>
   <button onclick="executarAcao('executar')">EXECUTAR</button>
-  <button onclick="executarAcao('automatico')">AUTOMÁTICO</button>
+  <form id="auto-form" method="post" action="/modo_automatico">
+    <button name="acao" value="start">INICIAR AUTO</button>
+    <button name="acao" value="stop">PARAR AUTO</button>
+  </form>
 </div>
+
+<p><a href="{{ url_for('config_api') }}">Configurar Binance API</a></p>
 
 <div class="sugestao-ia">
   <h3>Sugestão da IA Clarinha</h3>


### PR DESCRIPTION
## Summary
- store user Binance API keys encrypted and toggle testnet usage
- create per-user Binance client, GPT-driven strategy, and scheduler for automatic trades
- add dashboard routes and views for API configuration and auto mode control
- allow storing per-user OpenAI API key for GPT-based analysis
- handle missing APScheduler dependency gracefully to prevent import errors

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement APScheduler==3.10.4)*
- `python -m py_compile app.py binance_client.py strategy.py tasks.py models.py crypto_utils.py clarinha_ia.py clarinha_core.py`
- `python - <<'PY'
import app
print('imported')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689309155408832992bb825e44622fcd