### PR TITLE
Add painel_operacao view implementation

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,8 @@ def index():
 @app.route("/painel_operacao")
 @login_required
 def painel_operacao():
-
+    """Renderiza o painel principal de operações."""
+    return render_template("operacoes/painel_operacao.html")
 
 @app.route("/config_api", methods=["GET", "POST"])
 @login_required


### PR DESCRIPTION
## Summary
- define `painel_operacao` route to render operations panel template
- clarify docstring for the operations panel view

## Testing
- `python -m py_compile app.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'inteligencia_financeira')*


------
https://chatgpt.com/codex/tasks/task_e_6895733c4adc8329b3e3b2f52bff721c