### PR TITLE
feat: add RSI/MACD indicators with GPT analysis

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,9 +67,8 @@ def index():
 @app.route("/painel_operacao")
 @login_required
 def painel_operacao():
-
-
-
+    """Renderiza o painel principal de operações para o usuário logado."""
+    return render_template("operacoes/painel_operacao.html")
 @app.route("/config_api", methods=["GET", "POST"])
 @login_required
 def config_api():

--- a/inteligencia_financeira/rotas.py
+++ b/inteligencia_financeira/rotas.py
@@ -1,7 +1,93 @@
-from flask import render_template
+"""Rotas para a aplicação de inteligência financeira."""
+
+import os
+from flask import render_template, request
+from openai import OpenAI
+
 from . import bp
+from .utils import (
+    calcular_comissao,
+    calcular_macd,
+    calcular_media_movel,
+    calcular_performance,
+    calcular_rsi,
+    obter_dados_mercado,
+)
+
+
+api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=api_key) if api_key else None
 
 
 @bp.route('/')
 def analise():
-    return render_template('inteligencia_financeira/analise.html')
+    """Calcula indicadores e consulta o GPT para gerar uma análise."""
+
+    ticker = request.args.get("ticker", "demo")
+    periodo_rsi = request.args.get("rsi_periodo", 14, type=int)
+    macd_curto = request.args.get("macd_curto", 12, type=int)
+    macd_longo = request.args.get("macd_longo", 26, type=int)
+    macd_sinal = request.args.get("macd_sinal", 9, type=int)
+    mm_periodo = request.args.get("mm_periodo", 20, type=int)
+    taxa = request.args.get("taxa", 0.001, type=float)
+
+    valores = obter_dados_mercado(ticker)
+    erro_dados = False
+    if not valores:
+        erro_dados = True
+        valores = [
+            100, 101, 102, 99, 98, 100, 102, 101, 103, 105,
+            104, 106, 108, 107, 109, 111, 110, 112, 115, 113,
+            114, 116, 118, 117, 119, 121, 120, 122, 124, 123,
+            125, 127, 126, 128, 130, 129, 131, 133, 132, 134,
+        ]
+
+    rsi = calcular_rsi(valores, periodo_rsi)
+    macd, sinal = calcular_macd(valores, macd_curto, macd_longo, macd_sinal)
+    media_movel = calcular_media_movel(valores, mm_periodo)
+    performance = calcular_performance(valores)
+    comissao = calcular_comissao(performance, taxa)
+    performance_liquida = performance - comissao
+
+    analise_texto = "OPENAI_API_KEY não configurada"
+    if client is not None:
+        prompt = (
+            "Você é uma IA analista financeira. Considere os indicadores a seguir\n"
+            f"RSI: {rsi:.2f}\n"
+            f"MACD: {macd:.2f}\n"
+            f"Sinal: {sinal:.2f}\n"
+            f"Média Móvel: {media_movel:.2f}\n"
+            f"Performance: {performance_liquida:.2f}% após comissões\n"
+            "Forneça uma breve análise combinando estes indicadores."
+        )
+        try:
+            resp = client.chat.completions.create(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.4,
+                max_tokens=200,
+            )
+            analise_texto = resp.choices[0].message.content.strip()
+        except Exception as e:
+            analise_texto = f"Erro ao consultar GPT: {e}"
+
+    contexto = {
+        "rsi": rsi,
+        "macd": macd,
+        "sinal": sinal,
+        "media_movel": media_movel,
+        "valores": valores,
+        "performance": performance,
+        "comissao": comissao,
+        "performance_liquida": performance_liquida,
+        "analise": analise_texto,
+        "erro_dados": erro_dados,
+        "ticker": ticker,
+        "rsi_periodo": periodo_rsi,
+        "macd_curto": macd_curto,
+        "macd_longo": macd_longo,
+        "macd_sinal": macd_sinal,
+        "mm_periodo": mm_periodo,
+        "taxa": taxa,
+    }
+    return render_template("inteligencia_financeira/analise.html", **contexto)

--- a/inteligencia_financeira/utils.py
+++ b/inteligencia_financeira/utils.py
@@ -1,8 +1,145 @@
 """Funções auxiliares para análise financeira."""
 
+from __future__ import annotations
 
-def calcular_indicador_exemplo(valores: list[float]) -> float:
+import functools
+from typing import Iterable
+
+import requests
+
+
+def calcular_indicador_exemplo(valores: Iterable[float]) -> float:
     """Retorna a média simples dos valores fornecidos."""
+    valores = list(valores)
     if not valores:
         return 0.0
     return sum(valores) / len(valores)
+
+
+@functools.lru_cache(maxsize=32)
+def obter_dados_mercado(ticker: str) -> list[float]:
+    """Obtém preços de mercado para ``ticker``.
+
+    A função faz uma requisição HTTP simples e implementa ``lru_cache`` para
+    evitar chamadas repetidas. Qualquer exceção é capturada e uma lista vazia
+    é retornada, permitindo que a aplicação continue funcionando mesmo sem
+    conexão com a API externa.
+    """
+
+    url = f"https://example.com/market/{ticker}"
+    try:
+        resposta = requests.get(url, timeout=5)
+        resposta.raise_for_status()
+        dados = resposta.json().get("precos", [])
+        if not isinstance(dados, list):
+            return []
+        return [float(v) for v in dados]
+    except Exception:
+        return []
+
+
+def calcular_rsi(valores: list[float], periodo: int = 14) -> float:
+    """Calcula o Índice de Força Relativa (RSI).
+
+    O RSI é um oscilador que mede a velocidade e a mudança dos movimentos de preço.
+    Esta implementação utiliza a média simples dos ganhos e perdas dos últimos
+    ``periodo`` preços informados.
+
+    Args:
+        valores: Lista de preços de fechamento.
+        periodo: Janela de cálculo do RSI. Padrão de 14 períodos.
+
+    Returns:
+        Valor do RSI entre 0 e 100. Retorna 0 caso não haja dados suficientes.
+    """
+
+    if len(valores) < periodo + 1:
+        return 0.0
+
+    ganhos = 0.0
+    perdas = 0.0
+    for i in range(-periodo, 0):
+        delta = valores[i] - valores[i - 1]
+        if delta > 0:
+            ganhos += delta
+        else:
+            perdas += -delta
+
+    if periodo == 0:
+        return 0.0
+
+    media_ganho = ganhos / periodo
+    media_perda = perdas / periodo
+
+    if media_perda == 0:
+        return 100.0
+
+    rs = media_ganho / media_perda
+    return 100 - (100 / (1 + rs))
+
+
+def calcular_macd(
+    valores: list[float], curto: int = 12, longo: int = 26, sinal: int = 9
+) -> tuple[float, float]:
+    """Calcula o MACD (Moving Average Convergence Divergence).
+
+    Retorna a linha MACD e a linha de sinal usando médias móveis exponenciais
+    simples. Caso a lista de valores não seja suficiente, devolve (0.0, 0.0).
+
+    Args:
+        valores: Lista de preços de fechamento.
+        curto: Período da média móvel exponencial curta (EMA rápida).
+        longo: Período da média móvel exponencial longa (EMA lenta).
+        sinal: Período da média móvel da linha MACD.
+
+    Returns:
+        Tupla ``(macd, sinal)`` com os valores calculados.
+    """
+
+    if not valores:
+        return 0.0, 0.0
+
+    def ema_series(dados: list[float], periodo: int) -> list[float]:
+        """Retorna a série EMA para os dados informados."""
+        k = 2 / (periodo + 1)
+        ema_valor = dados[0]
+        serie = [ema_valor]
+        for preco in dados[1:]:
+            ema_valor = preco * k + ema_valor * (1 - k)
+            serie.append(ema_valor)
+        return serie
+
+    ema_curta = ema_series(valores, curto)
+    ema_longa = ema_series(valores, longo)
+
+    # Ajusta as séries para terem o mesmo tamanho
+    tamanho = min(len(ema_curta), len(ema_longa))
+    macd_series = [ema_curta[i] - ema_longa[i] for i in range(tamanho)]
+
+    sinal_series = ema_series(macd_series, sinal)
+
+    return macd_series[-1], sinal_series[-1]
+
+
+def calcular_media_movel(valores: Iterable[float], periodo: int = 20) -> float:
+    """Calcula a média móvel simples para ``periodo``."""
+    valores = list(valores)
+    if len(valores) < periodo or periodo <= 0:
+        return 0.0
+    return sum(valores[-periodo:]) / periodo
+
+
+def calcular_performance(valores: Iterable[float]) -> float:
+    """Retorna a variação percentual entre o primeiro e o último valor."""
+    valores = list(valores)
+    if len(valores) < 2:
+        return 0.0
+    inicial, final = valores[0], valores[-1]
+    if inicial == 0:
+        return 0.0
+    return (final - inicial) / inicial * 100
+
+
+def calcular_comissao(valor: float, taxa: float = 0.001) -> float:
+    """Calcula a comissão sobre ``valor`` aplicando ``taxa``."""
+    return valor * taxa

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/templates/inteligencia_financeira/analise.html
+++ b/templates/inteligencia_financeira/analise.html
@@ -2,4 +2,46 @@
 {% block title %}Análise Financeira{% endblock %}
 {% block content %}
 <h2>Inteligência Financeira</h2>
+
+<form method="get" class="mb-3">
+  <label>Ticker <input type="text" name="ticker" value="{{ ticker }}" /></label>
+  <label>RSI período <input type="number" name="rsi_periodo" value="{{ rsi_periodo }}" /></label>
+  <label>MACD curto <input type="number" name="macd_curto" value="{{ macd_curto }}" /></label>
+  <label>MACD longo <input type="number" name="macd_longo" value="{{ macd_longo }}" /></label>
+  <label>MACD sinal <input type="number" name="macd_sinal" value="{{ macd_sinal }}" /></label>
+  <label>MM período <input type="number" name="mm_periodo" value="{{ mm_periodo }}" /></label>
+  <label>Taxa <input type="number" step="0.0001" name="taxa" value="{{ taxa }}" /></label>
+  <button type="submit">Atualizar</button>
+</form>
+
+<p>RSI: <span class="{% if rsi>70 %}text-danger{% elif rsi<30 %}text-success{% endif %}">{{ rsi|round(2) }}</span></p>
+<p>MACD: {{ macd|round(2) }} | Sinal: {{ sinal|round(2) }}</p>
+<p>Média Móvel: {{ media_movel|round(2) }}</p>
+<p>Performance: {{ performance|round(2) }}% | Comissão: {{ comissao|round(4) }} | Líquida: {{ performance_liquida|round(2) }}%</p>
+
+{% if erro_dados %}
+<p class="text-warning">Dados de mercado indisponíveis, utilizando valores de demonstração.</p>
+{% endif %}
+
+<canvas id="grafico" width="400" height="200"></canvas>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  const dados = {{ valores|tojson }};
+  const ctx = document.getElementById('grafico').getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: dados.map((_, i) => i + 1),
+      datasets: [{
+        label: 'Preço',
+        data: dados,
+        borderColor: 'blue',
+        fill: false
+      }]
+    }
+  });
+</script>
+
+<h3>Análise</h3>
+<p>{{ analise }}</p>
 {% endblock %}

--- a/tests/test_financeira.py
+++ b/tests/test_financeira.py
@@ -1,0 +1,104 @@
+import pytest
+from flask import Flask
+import os
+
+from inteligencia_financeira import bp as finance_bp
+from inteligencia_financeira import rotas
+from inteligencia_financeira.utils import (
+    calcular_rsi,
+    calcular_macd,
+    calcular_media_movel,
+    calcular_performance,
+    calcular_comissao,
+)
+
+
+def create_app():
+    template_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
+    app = Flask(__name__, template_folder=template_dir)
+    app.register_blueprint(finance_bp)
+    return app
+
+
+def test_calcular_rsi_basic():
+    valores = list(range(1, 20))
+    rsi = calcular_rsi(valores)
+    assert 0 <= rsi <= 100
+
+
+def test_calcular_rsi_insuficiente():
+    """RSI deve retornar 0 com dados insuficientes."""
+    assert calcular_rsi([1, 2, 3], periodo=14) == 0.0
+
+
+def test_calcular_macd_basic():
+    valores = list(range(1, 60))
+    macd, sinal = calcular_macd(valores)
+    assert isinstance(macd, float)
+    assert isinstance(sinal, float)
+
+
+def test_calcular_macd_vazio():
+    """MACD vazio retorna zeros."""
+    macd, sinal = calcular_macd([])
+    assert macd == 0.0 and sinal == 0.0
+
+
+def test_utilidades_complementares():
+    valores = [10, 12, 14, 16, 18, 20]
+    assert calcular_media_movel(valores, 3) == pytest.approx(18)
+    perf = calcular_performance(valores)
+    assert perf > 0
+    comissao = calcular_comissao(perf, 0.01)
+    assert comissao == pytest.approx(perf * 0.01)
+
+
+def test_analise_route(monkeypatch):
+    app = create_app()
+    client = app.test_client()
+
+    # Garante dados determinísticos
+    monkeypatch.setattr(rotas, "obter_dados_mercado", lambda ticker: list(range(1, 60)))
+    monkeypatch.setattr(rotas, "render_template", lambda *a, **k: "ok")
+
+    resp = client.get("/inteligencia_financeira/?rsi_periodo=14")
+    assert resp.status_code == 200
+
+
+def test_analise_route_sem_api_key(monkeypatch):
+    app = create_app()
+    client = app.test_client()
+
+    contexto = {}
+
+    def fake_render(template, **ctx):
+        contexto.update(ctx)
+        return "ok"
+
+    monkeypatch.setattr(rotas, "render_template", fake_render)
+    monkeypatch.setattr(rotas, "obter_dados_mercado", lambda ticker: list(range(1, 60)))
+    monkeypatch.setattr(rotas, "client", None)
+
+    resp = client.get("/inteligencia_financeira/")
+    assert resp.status_code == 200
+    assert "OPENAI_API_KEY" in contexto["analise"]
+
+
+def test_analise_route_erro_dados(monkeypatch):
+    app = create_app()
+    client = app.test_client()
+
+    contexto = {}
+
+    def fake_render(template, **ctx):
+        contexto.update(ctx)
+        return "ok"
+
+    monkeypatch.setattr(rotas, "render_template", fake_render)
+    monkeypatch.setattr(rotas, "obter_dados_mercado", lambda ticker: [])
+    monkeypatch.setattr(rotas, "client", None)
+
+    resp = client.get("/inteligencia_financeira/")
+    assert resp.status_code == 200
+    assert contexto["erro_dados"] is True
+    assert len(contexto["valores"]) > 0


### PR DESCRIPTION
## Summary
- define painel_operacao Flask view with template render
- expand financial analysis helpers with RSI/MACD and GPT-backed narrative
- broaden test coverage for indicator utilities and analysis route error paths
- configure pytest to include repository root in Python path for imports

## Testing
- `python -m py_compile inteligencia_financeira/utils.py inteligencia_financeira/rotas.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689558acd3648329890b7a28eb8c144f