### PR TITLE
fix: initialize login manager and add auth routes

### DIFF
--- a/acessos/__init__.py
+++ b/acessos/__init__.py
@@ -1,5 +1,5 @@
 from flask import Blueprint
 
-
+bp = Blueprint("acessos", __name__, url_prefix="/acessos")
 
 from . import rotas

--- a/acessos/rotas.py
+++ b/acessos/rotas.py
@@ -1,2 +1,26 @@
+from flask import render_template, request, redirect, url_for, flash
+from flask_login import login_user, logout_user
+from werkzeug.security import check_password_hash
+
+from models import Usuario
+
+from . import bp
 
 
+@bp.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        usuario = request.form["usuario"]
+        senha = request.form["senha"]
+        user = Usuario.query.filter_by(usuario=usuario).first()
+        if user and check_password_hash(user.senha_hash, senha):
+            login_user(user)
+            return redirect(url_for("painel_operacao"))
+        flash("Credenciais inválidas", "danger")
+    return render_template("login.html")
+
+
+@bp.route("/logout")
+def logout():
+    logout_user()
+    return redirect(url_for("acessos.login"))

--- a/app.py
+++ b/app.py
@@ -10,12 +10,13 @@ from crypto_utils import criptografar
 from binance_client import get_client
 from tasks import start_auto_mode, stop_auto_mode
 
+from acessos import bp as acessos_bp
 from conectores import bp as conectores_bp
 from configuracao import bp as configuracao_bp
 from inteligencia_financeira import bp as inteligencia_financeira_bp
+from operacoes import bp as operacoes_bp
 from tokens import bp as tokens_bp
 from usuarios import bp as usuarios_bp
-from operacoes import bp as operacoes_bp
 
 load_dotenv()
 
@@ -27,7 +28,17 @@ app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///usuarios.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db.init_app(app)
 
+login_manager = LoginManager()
+login_manager.login_view = "acessos.login"
+login_manager.init_app(app)
 
+
+@login_manager.user_loader
+def load_user(user_id):
+    return Usuario.query.get(int(user_id))
+
+
+app.register_blueprint(acessos_bp)
 app.register_blueprint(conectores_bp)
 app.register_blueprint(configuracao_bp)
 app.register_blueprint(inteligencia_financeira_bp)
@@ -60,7 +71,7 @@ def index():
 @app.route("/painel_operacao")
 @login_required
 def painel_operacao():
-
+    return render_template("dashboard.html")
 @app.route("/config_api", methods=["GET", "POST"])
 @login_required
 def config_api():

--- a/templates/componentes/navbar.html
+++ b/templates/componentes/navbar.html
@@ -1,5 +1,3 @@
 <nav class="nav">
   <a href="{{ url_for('index') }}">Início</a>
-
-  {% endif %}
 </nav>


### PR DESCRIPTION
## Summary
- configure Flask LoginManager with user loader
- add acessos blueprint with login and logout routes
- clean up navbar template syntax

## Testing
- `python -m py_compile app.py acessos/rotas.py acessos/__init__.py`
- `python - <<'PY'
from app import app
client = app.test_client()
client.get('/')
client.get('/acessos/login')
client.post('/acessos/login', data={'usuario': 'admin', 'senha': 'claraverse2025'})
PY`


------
https://chatgpt.com/codex/tasks/task_e_68961b520518832994d99ac6dd2cf5a8