### PR TITLE
Fix Jinja block in dashboard template

### DIFF
--- a/templates/painel_operacao/dashboard.html
+++ b/templates/painel_operacao/dashboard.html
@@ -4,7 +4,4 @@
 {% block content %}
   <h2>Bem-vindo(a) ao ClaraVerse</h2>
   <p>A plataforma de operações reais com inteligência da IA Clarinha e integração direta com a Binance.</p>
-
-
-  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove stray closing `endif` from dashboard template

## Testing
- `python - <<'PY'
from jinja2 import Environment, FileSystemLoader, TemplateSyntaxError
env = Environment(loader=FileSystemLoader('templates'))
try:
    env.get_template('painel_operacao/dashboard.html')
    print('Template OK')
except TemplateSyntaxError as e:
    print('Error:', e)
PY`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68963d036cf08329bea60f545d952cd5