### PR TITLE
Rename operacoes painel route in favor of painel_operacao.index

### DIFF
--- a/operacoes/rotas.py
+++ b/operacoes/rotas.py
@@ -2,6 +2,7 @@ from flask import render_template
 from . import bp
 
 
-@bp.route('/')
-def painel():
+@bp.route('/painel')
+def painel_operacoes():
+    """Display the operations panel."""
     return render_template('operacoes/painel_operacao.html')

--- a/painel_operacao/rotas.py
+++ b/painel_operacao/rotas.py
@@ -5,4 +5,5 @@ from . import bp
 
 @bp.route('/')
 def index():
-
+    """Render the operations panel."""
+    return render_template('operacoes/painel_operacao.html')


### PR DESCRIPTION
## Summary
- avoid route overlap by moving operacoes painel route to `/operacoes/painel`
- ensure painel_operacao blueprint renders `operacoes/painel_operacao.html`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963d02eb7c8329933e7d7fa6c0dde4